### PR TITLE
Update QAPortal.cs

### DIFF
--- a/Library/QAPortal/QAPortal.cs
+++ b/Library/QAPortal/QAPortal.cs
@@ -44,6 +44,7 @@
 
 		private void PlainBodyEmail(string message, string subject, string to)
 		{
+			to = "qaportal@skyline.be";
 			EmailOptions emailOptions = new EmailOptions(message, subject, to)
 			{
 				SendAsPlainText = true,


### PR DESCRIPTION
By default the "to" is equal to "https://qaportal.skyline.be/forward/save" which is the URL of the API, but we need to pass the email address